### PR TITLE
Fixing peers table and adding unix timestamp functionality

### DIFF
--- a/expressApp.js
+++ b/expressApp.js
@@ -25,6 +25,10 @@ const expressApp = express();
 
 expressApp.use(cors());
 
+expressApp.get('/time', (req, res) => {
+    res.send(`${Math.floor(Date.now() / 1000)}`);
+});
+
 expressApp.get('/syncing', async (req, res) => {
   //await syncing.resetTx404();
   //await syncing.deleteBlackTxsAndAddress();

--- a/src/syncing.js
+++ b/src/syncing.js
@@ -137,6 +137,7 @@
                   location TEXT not null,
                   area_code TEXT not null,
                   country_code TEXT not null,
+                  mining_address TEXT,
                   status INTEGER DEFAULT 0
               );
           `);
@@ -4297,6 +4298,15 @@
     }
   };
 
+  async function getTime() {
+    try {
+        const response = await axios.get("http://"+Item.ip+"/time");
+        console.log(`Unix Timestamp: ${response.data}`);
+    } catch (error) {
+        console.error('Error fetching time:', error);
+    }
+  };
+
   export default {
     initChivesLightNode,
     initChivesLightNodeSql,
@@ -4390,5 +4400,6 @@
     mkdirForData,
     deleteBlackTxsAndAddress,
     restrictToLocalhost,
-    closeDb
+    closeDb,
+    getTime
   };


### PR DESCRIPTION
**peers table:**
When starting the light node for the first time, the table is created without the `mining_address` column, which throws an error.

**time feature:**
Mining nodes trying to connect to the light node will request the current time of the light node via the http /time API method, which doesn't exist.